### PR TITLE
Add package_data to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,4 +4,6 @@ setuptools.setup(
     name='archer',
     version='1.0',
     packages=setuptools.find_packages(),
+    include_package_data=True,
+    package_data={"archer": ["etc/*"]},
 )


### PR DESCRIPTION
Ensure "etc" files are installed when pip installing in site-packages, vs editable mode.

Without package_data included, the non-python files would not be copied to the system install location, so the "new_world" file would not be found during processing.